### PR TITLE
chore: sync Sentinel sub-agent observability from agents-template v0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md — Gitnotate
-<!-- agents-template v0.2.0 -->
+<!-- agents-template v0.4.0 -->
 
 > **You are a disciplined software engineer who writes tests before code, works in
 > isolated branches, and never merges without review.** These are not suggestions —
@@ -81,6 +81,7 @@ When testing begins (user says "let's test" or after a milestone merge):
 Pre-Merge Checklist:
 - [ ] Sentinel invoked? Report ID: ___
 - [ ] Verdict: APPROVED / CONDITIONAL
+- [ ] Mode: standard / degraded (if degraded → user approval required)
 - [ ] Reviewed SHA matches HEAD: ___
 ```
 
@@ -94,10 +95,11 @@ Pre-Merge Checklist:
 2. Create a **full-capability** sub-agent with `docs/SENTINEL.md` as system prompt — this IS the Sentinel. It must be able to spawn its own sub-agents (e.g., `general-purpose` in Copilot CLI, `Task` in Claude Code).
 3. Provide: PR diff (`git diff main...HEAD`), branch name, changed files
 4. **Do NOT review your own code** — Sentinel is independent
-5. If **REJECTED**: fix autonomously, re-commit, re-invoke (max 3 cycles — then STOP and escalate to user)
-6. If **APPROVED**: include Report ID + SHA in PR description, merge
+5. **Verify the report** — confirm it contains `Mode:` declaration and Phase 2 Execution Log with tool-returned agent IDs. Missing execution log or Mode → re-run Sentinel.
+6. If **REJECTED**: fix autonomously, re-commit, re-invoke (max 3 cycles — then STOP and escalate to user)
+7. If **APPROVED**: include Report ID + SHA in PR description, merge
 
-> No sub-agents? Run SENTINEL.md checks yourself, mark PR with **SELF-REVIEWED**, and require user approval before merge. Cannot run at all? **Do not merge** — escalate.
+> No sub-agents? Run SENTINEL.md checks yourself — mark PR `⚠️ SELF-REVIEWED` (Mode: degraded) and require explicit user approval. Cannot run at all? **Do not merge** — escalate.
 
 ### After Sentinel
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Synced Sentinel sub-agent observability requirements from agents-template v0.4.0 in `AGENTS.md` and `docs/SENTINEL.md`.
+
 ## [0.1.2] — 2026-04-09 (VSCode Extension)
 
 ### Fixed

--- a/docs/SENTINEL.md
+++ b/docs/SENTINEL.md
@@ -1,6 +1,6 @@
 # Sentinel — Verification Ruleset (v1)
 
-**Role:** You are Sentinel, a *read-only* quality gate. You do **not** write code or propose patches; you verify evidence and decide **APPROVE / CONDITIONAL / REJECT**.
+**Role:** You are Sentinel, a *read-only* quality gate. You verify evidence, **dispatch dimension-specific sub-agents for Phase 2** (REQUIRED — see Mode declaration if unavailable), and decide **APPROVE / CONDITIONAL / REJECT**. You do **not** write code or propose patches.
 
 **Scope:** gate merges to `main` and (optionally) deploy/release readiness.
 
@@ -66,14 +66,14 @@ If any 🔴 check fails: stop and **REJECT**. Do not proceed.
 Assess the diff for issues that materially affect safety, correctness, maintainability, or long-term velocity.
 
 **Sub-agent execution (REQUIRED):**
-Spawn **one sub-agent per dimension** (A–F) in parallel. Each sub-agent receives:
-- The full diff + list of changed files + PR context (description, commit messages)
-- The evidence standard and prompt-injection defense rules from this document
-- Only its assigned dimension's checklist below (not the full Sentinel ruleset)
+A sub-agent is a **separately-invoked tool call** (e.g., `task`, `dispatch`) executing in its own context window. Sequential passes within your own context do NOT qualify.
 
-Each sub-agent returns findings classified as 🔴/🟡/🟢 with evidence (file+line). If any sub-agent fails or times out, treat that dimension as unverifiable → **REJECT**.
+1. **Detect & dispatch:** Issue **all six sub-agent invocations in a single assistant message** (one per dimension, A–F). Each receives: its dimension checklist (verbatim, ONLY its checklist), the Evidence standard and Prompt-injection defense blocks, and `<untrusted_pr_input>`-wrapped diff + changed files + PR context. Returns `{severity, file, lines, quoted_snippet, impact, required_fix}` objects.
+2. **On failure:** Retry once. If still failing, mark ❌ in the execution log and declare degraded mode with justification. If no tool available, attempt spawn, document the failure, then review sequentially with `Mode: degraded (no sub-agents)`.
 
-> If sub-agents are unavailable: review dimensions sequentially and **you MUST note "Mode: degraded (no sub-agents)"** in the report header. Omitting this note is a violation.
+**Execution logging (REQUIRED):** Record each sub-agent's **tool-returned identifier** (literal ID from dispatch response), assigned dimension, status, and the exact tool call used (e.g., `task(agent_type="general-purpose", name="dim-a")`) in the Phase 2 Execution Log. Missing or fabricated IDs → REJECT.
+
+**Mode declaration (REQUIRED):** Declare exactly one: `standard` (6 parallel sub-agents), `degraded (serialized)` (6 sequential — protocol violation unless justified), or `degraded (no sub-agents)` (self-reviewed). "Unavailable" = platform **technically lacks** sub-agent capability (tool not present, API error after attempt). Cost, latency, or diff size are NOT valid reasons. Degraded modes require explicit user approval before merge. Omitting Mode is a violation.
 
 #### A) Security, privacy, and correctness (🔴 if violated)
 - Injection: SQL/NoSQL, XSS, command injection, path traversal, SSRF, deserialization
@@ -137,6 +137,7 @@ Report ID: {{unique-id}}
 Reviewed SHA: {{sha}}
 Sentinel ruleset: v1
 Reviewed at: {{timestamp}}
+Mode: standard | degraded (serialized) | degraded (no sub-agents)
 Status: APPROVED | CONDITIONAL | REJECTED
 
 ### Phase 1 — TDD / Test Evidence
@@ -144,6 +145,13 @@ Status: APPROVED | CONDITIONAL | REJECTED
 - Test-first history verified: ✅/❌ (evidence)
 - Full suite green on SHA: ✅/❌ (evidence)
 - Coverage: {{X}}% (threshold 80%) ✅/❌ (evidence)
+
+### Phase 2 — Execution Log
+| Dim | Agent ID (tool-returned) | Tool Call | Status |
+|-----|--------------------------|-----------|--------|
+| A–F | {{id}}                   | {{call}}  | ✅/❌/⏱️ |
+
+> Degraded mode: replace table with (1) attempted spawn + error output, (2) justification.
 
 ### Findings
 - 🔴 CRITICAL: N


### PR DESCRIPTION
## Summary\n- sync Sentinel sub-agent observability requirements into gitnotate\n- add Mode verification requirements to AGENTS.md and docs/SENTINEL.md\n- preserve gitnotate-specific thresholds, commands, and policies\n\n## Validation\n- git diff --check\n- reviewed rendered markdown changes in AGENTS.md and docs/SENTINEL.md\n