### PR TITLE
docs(release): document Release Please workflow and versioning strategy

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -53,3 +53,11 @@
 **Decision**: Primary auth via GitHub OAuth App; Personal Access Token as fallback.
 **Alternatives considered**: PAT only; GitHub App installation tokens.
 **Consequences**: OAuth provides better UX for most users. PAT fallback supports enterprise/restricted environments.
+
+### ADR-005: Independent Versioning with Release Please
+**Date**: 2026-05-25
+**Status**: Accepted
+**Context**: The monorepo ships two user-facing products — a browser extension and a VSCode extension — that evolve on independent timelines. A single version number would force synchronized releases even when only one package has changes. We also needed automated changelog generation and version bumping from conventional commits.
+**Decision**: Version browser-extension and vscode-extension independently using [Release Please](https://github.com/googleapis/release-please). Each package gets its own Release Please component, separate version-bump PRs, and independent changelogs. Release Please is configured with `skip-github-release: true` — it only creates version-bump PRs (updating `package.json`, `CHANGELOG.md`, and `.release-please-manifest.json`). After merging a Release Please PR, a developer manually creates a tag (`browser-vX.Y.Z` or `vscode-vX.Y.Z`) to trigger the corresponding release workflow.
+**Alternatives considered**: Single version for all packages (forces unnecessary releases); fully automated releases via Release Please GitHub releases (tags created by `GITHUB_TOKEN` don't trigger other workflows, would require a PAT); manual versioning without automation (error-prone, no changelog generation).
+**Consequences**: Each package can release independently without coordinating versions. Changelogs are generated automatically from conventional commits. The manual tagging step is intentional — it gives developers a final gate before publishing to the Chrome Web Store and VS Code Marketplace. Tag naming convention (`browser-v*`, `vscode-v*`) matches existing release workflows. Internal packages (`core`, `github-action`) are not configured for Release Please since they are not published independently.

--- a/docs/DEVELOPMENT-WORKFLOW.md
+++ b/docs/DEVELOPMENT-WORKFLOW.md
@@ -122,6 +122,86 @@ cd packages/browser-extension && pnpm build   # Builds to dist/
 # Load dist/ as unpacked extension in Chrome/Edge
 ```
 
-> **Not yet released:** The VSCode extension (`packages/vscode-extension`) and
-> GitHub Action (`packages/github-action`) are planned for Phase 2 and are not
-> included in the v0.1.0 release.
+## Releasing
+
+Gitnotate uses [Release Please](https://github.com/googleapis/release-please) for automated versioning and changelog generation, with manual tagging to trigger release workflows.
+
+### How It Works
+
+```
+push to main ──► Release Please creates/updates version-bump PR
+                  (bumps package.json, updates CHANGELOG.md)
+
+merge RP PR ──► version bump lands on main
+
+create tag ───► release workflow builds, packages, and publishes
+```
+
+The browser extension and VSCode extension are versioned **independently** — each gets its own Release Please PR and changelog (see [ADR-005](./DECISIONS.md#adr-005-independent-versioning-with-release-please)).
+
+### Automated: Version Bump PRs
+
+Release Please runs on every push to `main` and analyzes conventional commit messages:
+- `feat(browser):` → minor version bump for browser-extension
+- `fix(vscode):` → patch version bump for vscode-extension
+- `feat!:` or `BREAKING CHANGE:` → major version bump
+
+It creates (or updates) a PR per component with:
+- Updated `package.json` version
+- Updated `CHANGELOG.md` with categorized entries
+- Updated `.release-please-manifest.json`
+
+> **Note:** Release Please is configured with `skip-github-release: true`. It only creates PRs — it does not create GitHub releases or tags automatically. This is intentional (see ADR-005).
+
+### Manual: Cutting a Release
+
+After merging a Release Please PR, create a tag to trigger the release workflow:
+
+#### Browser Extension
+```bash
+# Check the version that was just bumped
+cat packages/browser-extension/package.json | grep '"version"'
+
+# Create and push the tag
+git tag browser-v<VERSION>    # e.g., browser-v0.3.0
+git push origin browser-v<VERSION>
+```
+
+This triggers `.github/workflows/release.yml`, which:
+1. Runs core + browser-extension tests
+2. Builds all packages
+3. Packages the browser extension as a `.zip`
+4. Creates a GitHub Release with the `.zip` attached
+
+#### VSCode Extension
+```bash
+# Check the version that was just bumped
+cat packages/vscode-extension/package.json | grep '"version"'
+
+# Create and push the tag
+git tag vscode-v<VERSION>    # e.g., vscode-v0.2.0
+git push origin vscode-v<VERSION>
+```
+
+This triggers `.github/workflows/release-vscode.yml`, which:
+1. Runs core + vscode-extension tests
+2. Builds all packages
+3. Packages the `.vsix`
+4. Publishes to the VS Code Marketplace (requires `VSCE_PAT` secret)
+5. Publishes to Open VSX (optional, requires `OVSX_PAT` secret)
+6. Creates a GitHub Release with the `.vsix` attached
+
+### Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `release-please-config.json` | Monorepo config: components, changelog sections, `skip-github-release` |
+| `.release-please-manifest.json` | Current versions for each component |
+| `.github/workflows/release-please.yml` | Workflow that runs Release Please on push to main |
+
+### Tag Naming Convention
+
+| Package | Tag Pattern | Example |
+|---------|------------|---------|
+| Browser Extension | `browser-v*` | `browser-v0.3.0` |
+| VSCode Extension | `vscode-v*` | `vscode-v0.2.0` |


### PR DESCRIPTION
Add documentation for the Release Please workflow introduced in PR #59.

## Changes
- **DECISIONS.md**: Add ADR-005 documenting independent versioning strategy with Release Please
- **docs/DEVELOPMENT-WORKFLOW.md**: Add Releasing section with step-by-step instructions for cutting browser and VSCode extension releases

## Motivation
Sentinel flagged a documentation gap (🟡) during PR #59 review — the Release Please setup had no accompanying docs explaining how to use it.

Closes #46