### PR TITLE
fix(highlighter): resolve incomplete CSS escaping in clearHighlight (CodeQL #4)

### DIFF
--- a/packages/browser-extension/src/content/highlighter.ts
+++ b/packages/browser-extension/src/content/highlighter.ts
@@ -244,11 +244,11 @@ export function clearAllHighlights(): void {
  * Remove highlights for a specific comment ID.
  */
 export function clearHighlight(commentId: string): void {
-  const spans = document.querySelectorAll<HTMLElement>(
-    `.gn-highlight[data-gn-comment-id="${commentId.replace(/"/g, '\\"')}"]`,
-  );
+  const spans = document.querySelectorAll<HTMLElement>('.gn-highlight');
   for (const span of spans) {
-    unwrapSpan(span);
+    if (span.getAttribute('data-gn-comment-id') === commentId) {
+      unwrapSpan(span);
+    }
   }
 }
 

--- a/packages/browser-extension/tests/content/highlighter.test.ts
+++ b/packages/browser-extension/tests/content/highlighter.test.ts
@@ -491,6 +491,20 @@ describe('clearHighlight', () => {
   it('should not crash when clearing a non-existent highlight', () => {
     expect(() => clearHighlight('does-not-exist')).not.toThrow();
   });
+
+  it('should clear a highlight whose comment ID contains a backslash', () => {
+    const file = buildDiffLine('file.ts', 1, 'alpha beta');
+    document.body.appendChild(file);
+
+    const commentId = 'id-with\\backslash';
+    highlightTextRange(makeInfo({ filePath: 'file.ts', lineNumber: 1, start: 0, end: 5, commentId }));
+
+    expect(document.querySelectorAll('.gn-highlight')).toHaveLength(1);
+
+    clearHighlight(commentId);
+
+    expect(document.querySelectorAll('.gn-highlight')).toHaveLength(0);
+  });
 });
 
 describe('clearAllHighlights', () => {


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning alert [#4](https://github.com/pedrofuentes/gitnotate/security/code-scanning/4) — **Incomplete string escaping or encoding** (`js/incomplete-sanitization`, severity: high).

## Problem

`clearHighlight()` built a CSS attribute selector using `commentId.replace(/"/g, '\\"')`, which escaped double quotes but **not backslashes**. A `commentId` containing `\"` would produce `\\"` — an escaped backslash followed by an unescaped quote — breaking the CSS selector.

## Solution

Replaced the CSS attribute selector approach with direct JS filtering on `querySelectorAll('.gn-highlight')` results. This:
- **Eliminates the entire class of CSS escaping bugs** — no escaping needed
- **Works in all environments** — avoids a jsdom/nwsapi limitation where backslash escapes in quoted attribute values are not supported
- **Simpler code** — 4 lines instead of a complex selector string

## TDD Compliance

```
554048b test(highlighter): add failing test for backslash in clearHighlight commentId
5046703 fix(highlighter): use JS filtering instead of incomplete CSS escaping
```

Test confirms the backslash-containing `commentId` case now works correctly.
