### PR TITLE
chore(deps): bump vite and js-yaml to patch security advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
       "serialize-javascript": ">=7.0.5",
       "diff": ">=8.0.3",
       "lodash": "4.18.1",
-      "vite": "6.4.2",
+      "vite": "6.4.3",
       "postcss": "8.5.10",
-      "esbuild": ">=0.28.1"
+      "esbuild": ">=0.28.1",
+      "js-yaml": ">=4.2.0",
+      "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,11 @@ overrides:
   serialize-javascript: '>=7.0.5'
   diff: '>=8.0.3'
   lodash: 4.18.1
-  vite: 6.4.2
+  vite: 6.4.3
   postcss: 8.5.10
   esbuild: '>=0.28.1'
+  js-yaml: '>=4.2.0'
+  brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
 
 importers:
 
@@ -63,8 +65,8 @@ importers:
         specifier: ^29.0.1
         version: 29.0.1
       vite:
-        specifier: 6.4.2
-        version: 6.4.2(@types/node@25.5.0)(tsx@4.21.0)
+        specifier: 6.4.3
+        version: 6.4.3(@types/node@25.5.0)(tsx@4.21.0)
 
   packages/core: {}
 
@@ -896,7 +898,7 @@ packages:
     resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 6.4.2
+      vite: 6.4.3
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1068,8 +1070,8 @@ packages:
   brace-expansion@2.0.3:
     resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -1540,8 +1542,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@29.0.1:
@@ -2031,8 +2033,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@6.4.2:
-    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -2382,7 +2384,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2866,13 +2868,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.6(vite@6.4.2(@types/node@25.5.0)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.6(vite@6.4.3(@types/node@25.5.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@25.5.0)(tsx@4.21.0)
+      vite: 6.4.3(@types/node@25.5.0)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -3058,7 +3060,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3524,7 +3526,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -3630,7 +3632,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -3657,7 +3659,7 @@ snapshots:
       glob: 10.5.0
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
@@ -4057,7 +4059,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.2(@types/node@25.5.0)(tsx@4.21.0)
+      vite: 6.4.3(@types/node@25.5.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4072,7 +4074,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.2(@types/node@25.5.0)(tsx@4.21.0):
+  vite@6.4.3(@types/node@25.5.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4089,7 +4091,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@6.4.2(@types/node@25.5.0)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.6(vite@6.4.3(@types/node@25.5.0)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -4107,7 +4109,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.2(@types/node@25.5.0)(tsx@4.21.0)
+      vite: 6.4.3(@types/node@25.5.0)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@25.5.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## Summary

Patches the **3 open Dependabot alerts** (all transitive dev dependencies) and brings `pnpm audit` to **0**.

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #22 | vite | 🟠 HIGH | `6.4.2` → `6.4.3` (GHSA-fx2h-pf6j-xcff — `server.fs.deny` bypass on Windows) |
| #23 | vite | 🟡 MEDIUM | `6.4.2` → `6.4.3` (GHSA-v6wh-96g9-6wx3 — launch-editor NTLMv2 disclosure) |
| #21 | js-yaml | 🟡 MEDIUM | → `>=4.2.0` (GHSA-h67p-54hq-rp68 — quadratic-complexity DoS) |

## Changes (root `package.json` → `pnpm.overrides`)
- **`vite`** `6.4.2` → `6.4.3` — the existing override pinned a version that itself became vulnerable; bumped to the patched release.
- **`js-yaml`** added `>=4.2.0` (pulled transitively via `eslint > @eslint/eslintrc`).
- **`brace-expansion`** added a **range-scoped** override `brace-expansion@>=5.0.0 <5.0.6` → `>=5.0.6` (GHSA-jxxr-4gwj-5jf2). Not Dependabot-tracked, included as hardening to reach a clean audit. The scoped key bumps only the vulnerable `5.0.5` instance and leaves the `1.1.13` / `2.0.3` lines untouched.

## Verification
- ✅ `pnpm lint` — 0 warnings
- ✅ `tsc --noEmit` — core, browser-extension, vscode-extension
- ✅ `pnpm test` — **744 tests pass** (79 / 249 / 416)
- ✅ `pnpm build` — all packages (browser-extension builds on vite 6.4.3)
- ✅ `pnpm audit` — **No known vulnerabilities found (0)** ⬅ down from 4 on this branch's base

## Notes
- Supersedes the stale Dependabot PR that bumped vite `6.4.1 → 6.4.2` (6.4.2 is itself vulnerable; this goes to 6.4.3).
