### PR TITLE
docs(sentinel): sync agents-template v0.17.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- agents-template v0.16.0 -->
+<!-- agents-template v0.17.0 -->
 # AGENTS.md — Gitnotate
 
 <role>You write tests before code, work in isolated worktree branches, and never merge without Sentinel review. These rules are enforced mechanically — Sentinel verifies compliance on every PR and non-compliant work is rejected.</role>

--- a/docs/SENTINEL.md
+++ b/docs/SENTINEL.md
@@ -86,7 +86,7 @@ The orchestrator MUST evaluate fast-path eligibility for every PR that passes Ph
 **Tier 2 skip criteria (ALL must be true):**
 - Quick scan found zero 🔴
 - Diff ≤ 150 non-test/non-lockfile lines changed
-- No files in security-sensitive paths (`auth/`, `crypto/`, `middleware/`, `migrations/`)
+- No files in security-sensitive paths (`auth/`, `crypto/`, `middleware/`, `migrations/`) or project-defined sensitive surfaces (AGENTS.md §NEVER), incl. modules rendering untrusted input to a terminal/UI
 - No new dependencies added
 - Commit types are `fix`, `refactor`, `docs`, `test`, `style`, or `chore`
 
@@ -178,6 +178,8 @@ Aggregate findings from all Phase 2 sub-agents, then classify using exactly thes
 Produce a single report in this structure:
 
 ```markdown
+Status: APPROVED | CONDITIONAL | REJECTED
+
 ## Sentinel Review Report
 
 Ref: {{branch}} → main
@@ -187,7 +189,6 @@ Sentinel ruleset: v1
 Reviewed at: {{timestamp}}
 Mode: standard | standard (fast-path) | degraded (serialized) | degraded (no sub-agents)
 Review depth: Tier 1 (fast-path) | Tier 2 (full)
-Status: APPROVED | CONDITIONAL | REJECTED
 Required action: MERGE | FILE_ISSUES_AND_MERGE | FIX_AND_REINVOKE
 
 ### Phase 1 — TDD / Test Evidence

--- a/docs/sentinel/dim-a1-security-attacks.md
+++ b/docs/sentinel/dim-a1-security-attacks.md
@@ -31,6 +31,7 @@ User-controlled values flowing into dangerous sinks without context-appropriate 
 - **SSRF** — user-controlled URLs in server-side HTTP requests, including `file://`, `gopher://` schemes.
 - **Deserialization** — untrusted data deserialized without validation (`pickle.loads`, `JSON.parse` of user input into typed objects, `ObjectInputStream`).
 - **Log/header injection** — unescaped newlines (`\r\n`) in user input written to logs or HTTP headers; enables log forging, response splitting.
+- **Terminal/ANSI/OSC escape injection** — untrusted content (user input, file/DB/prompt contents, summaries, log lines) written to stdout/stderr/TTY without stripping control characters. Enables output spoofing, cursor/title/clipboard manipulation, and hidden-command injection in some terminals. Safe: strip/escape C0/C1 control bytes and ANSI/OSC sequences before display.
 - **Open redirect** — `redirect(request.params.next)` without URL allowlist. Common in auth flows.
 - **Prototype pollution** (JS) — `Object.assign({}, untrusted)`, recursive merges, `_.merge` with user-controlled keys. Check for `__proto__`, `constructor.prototype`.
 - **ReDoS** — user-controlled input matched against regex with catastrophic backtracking (e.g., `(a+)+$`). Flag user-compiled regex.


### PR DESCRIPTION
Syncs the Sentinel spec to agents-template v0.17.0 (docs-only).

- dim-a1 Injection: add Terminal/ANSI/OSC escape injection sink.
- SENTINEL.md Phase 1.5: fast-path escalates when untrusted content is rendered to a terminal/UI (skip-criteria now project-aware).
- SENTINEL.md report template: leads with Status: to satisfy the first-non-blank-line anti-truncation mandate.
- AGENTS.md: bump template version marker to v0.17.0.

No code or tests affected. Upstream: pedrofuentes/agents-template v0.17.0.